### PR TITLE
fix terminology build

### DIFF
--- a/Dockerfile.terminology
+++ b/Dockerfile.terminology
@@ -12,6 +12,7 @@ RUN apt-get -y update && \
 
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
+ADD lib/onc_certification_g10_test_kit/version.rb $INSTALL_PATH/lib/onc_certification_g10_test_kit/version.rb
 RUN gem install bundler
 # The below RUN line is commented out for development purposes, because any change to the 
 # required gems will break the dockerfile build process.

--- a/lib/inferno/terminology/tasks/cleanup_precursors.rb
+++ b/lib/inferno/terminology/tasks/cleanup_precursors.rb
@@ -1,3 +1,5 @@
+require_relative 'temp_dir'
+
 module Inferno
   module Terminology
     module Tasks


### PR DESCRIPTION
Fixes #26 

This PR fixes two issues I encountered while trying to run the terminology build in the latest RC version. After these two changes, I was able to build terminologies successfully on a machine running Amazon Linux 2.

The first issue fixed is that the Docker build was unable to locate `onc_certification_g10_test_kit/version` in the `bundle install` step.

The second issue fixed is that the cleanup_precursors module was unable to locate the TempDir include.

Please let me know if I need to make any changes to this pull request. I couldn't find any contribution guidelines in this repo, so I tried my best to format it in a way similar to the closed pull requests.

- Daniel